### PR TITLE
[BUGFIX] Fix broken hour calculation

### DIFF
--- a/Classes/Utility/TimeFormatUtility.php
+++ b/Classes/Utility/TimeFormatUtility.php
@@ -16,7 +16,7 @@ class TimeFormatUtility
     public static function getFormattedTime(int $value): string
     {
         $value = (int)$value;
-        $hours = (string)floor($value / 3600);
+        $hours = (string)floor(($value / 3600) % 24);
         $minutes = (string)floor(($value / 60) % 60);
 
         return str_pad($hours, 2, '0', STR_PAD_LEFT) . ':' . str_pad($minutes, 2, '0', STR_PAD_LEFT);


### PR DESCRIPTION
In case the slot ends on the next day, the calculation is broken and returns e.g. 24:30

Fixes # .

### Prerequisites

* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

[Description of changes proposed in this pull request]

### Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
